### PR TITLE
feat: flatten import paths

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: airbyte-api
+  sdkClassName: airbyte-sdk
   usageSnippets:
     optionalPropertyRendering: withExample
   useClassNamesForArrayFields: true

--- a/gen.yaml
+++ b/gen.yaml
@@ -17,11 +17,11 @@ python:
   imports:
     option: openapi
     paths:
-      callbacks: models/callbacks
-      errors: models/errors
-      operations: models/operations
-      shared: models/shared
-      webhooks: models/webhooks
+      callbacks: ""
+      errors: ""
+      operations: ""
+      shared: ""
+      webhooks: ""
   inputModelSuffix: input
   maxMethodParams: 0
   outputModelSuffix: output

--- a/gen.yaml
+++ b/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: airbyte
+  sdkClassName: airbyte-api
   usageSnippets:
     optionalPropertyRendering: withExample
   useClassNamesForArrayFields: true


### PR DESCRIPTION
Please note this is a breaking change: 
- Changes imports for SDK models and other classes to the global path
- Changes the SDK class name 