### PR TITLE
Change (breaking!): Rename import to `airbyte_api` to make `airbyte-api` compatible with PyAirbyte

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: airbyte.sdk
+  sdkClassName: airbyte_api
   usageSnippets:
     optionalPropertyRendering: withExample
   useClassNamesForArrayFields: true

--- a/gen.yaml
+++ b/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: airbyte_api
+  sdkClassName: airbyte-api
   usageSnippets:
     optionalPropertyRendering: withExample
   useClassNamesForArrayFields: true
@@ -19,11 +19,11 @@ python:
   imports:
     option: openapi
     paths:
-      callbacks: models/callbacks
-      errors: models/errors
-      operations: models/operations
-      shared: models/shared
-      webhooks: models/webhooks
+      callbacks: ""
+      errors: ""
+      operations: ""
+      shared: ""
+      webhooks: ""
   inputModelSuffix: input
   maxMethodParams: 0
   outputModelSuffix: output

--- a/gen.yaml
+++ b/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: airbyte
+  sdkClassName: airbyte.sdk
   usageSnippets:
     optionalPropertyRendering: withExample
   useClassNamesForArrayFields: true
@@ -11,7 +11,7 @@ generation:
   auth:
     oAuth2ClientCredentialsEnabled: false
 python:
-  version: 0.47.3
+  version: 0.48.0
   author: Airbyte
   clientServerStatusCodesAsErrors: true
   description: Python Client SDK for Airbyte API


### PR DESCRIPTION
Resolves #67 