### PR TITLE
chore: pin speakeasy cli version to maintain python v1 functionality

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,11 @@
+# !NOTE: Speakeasy CLI version 1.508.0 is the last version compatible with the Python v1 
+# generator. After upgrading to the Python v2 generator, update `speakeasyVersion` to 
+# `latest` to ensure you continue to receive the latest updates.
+# 
+# See: https://www.speakeasy.com/docs/manage/migrate/python-migration
+
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: 1.508.0
 sources:
     my-source:
         inputs:


### PR DESCRIPTION
Howdy!

This PR pins the Speakeasy CLI version to 1.508.0 to ensure GitHub Actions and local executions of the SDK generation software continue running without interruptions.

Speakeasy’s Python v1 SDK generator is officially deprecated. To continue receiving the latest updates and bug fixes, please upgrade to v2 at your earliest convenience. [Click here for more information](https://www.speakeasy.com/docs/manage/migrate/python-migration).