### PR TITLE
Content-Type header for the token request (#126)

### DIFF
--- a/src/airbyte_api/_hooks/clientcredentials.py
+++ b/src/airbyte_api/_hooks/clientcredentials.py
@@ -116,7 +116,7 @@ class ClientCredentialsHook(SDKInitHook, BeforeRequestHook, AfterErrorHook):
         if not bool(urlparse(credentials.token_url).netloc):
             token_url = urljoin(self.base_url, credentials.token_url)
 
-        response = self.client.post(token_url, data=payload)
+        response = self.client.post(token_url, json=payload)
 
         if response.status_code < 200 or response.status_code >= 300:
             raise Exception(


### PR DESCRIPTION
Proper headed Content-Type with value `application/json` was added to the token requests