### PR TITLE
Pin GitHub Actions to SHA1 for supply chain security

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -15,7 +15,7 @@ permissions:
         - cron: 0 0 * * *
 jobs:
     generate:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@f09110c4676497cba7ef85034a6fb94191f1c417 # v15
         with:
             force: ${{ github.event.inputs.force }}
             mode: pr

--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -7,7 +7,7 @@ name: Publish
             - RELEASES.md
 jobs:
     publish:
-        uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@f09110c4676497cba7ef85034a6fb94191f1c417 # v15
         secrets:
             github_access_token: ${{ secrets.GITHUB_TOKEN }}
             pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to their specific SHA1 hashes to reduce supply chain attack risk
- Replaces version tags with specific commit SHAs
- Includes version comments for easier reference
- Changes generated with the pinact tool

More information: See internal supply-chain-security wiki page

## Changes
- `speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15` → `...@f09110c4676497cba7ef85034a6fb94191f1c417` # v15
- `speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15` → `...@f09110c4676497cba7ef85034a6fb94191f1c417` # v15