### PR TITLE
Fix on client_credentials no working

### DIFF
--- a/src/airbyte_api/_hooks/clientcredentials.py
+++ b/src/airbyte_api/_hooks/clientcredentials.py
@@ -116,7 +116,7 @@ class ClientCredentialsHook(SDKInitHook, BeforeRequestHook, AfterErrorHook):
         if not bool(urlparse(credentials.token_url).netloc):
             token_url = urljoin(self.base_url, credentials.token_url)
 
-        response = self.client.post(token_url, data=payload)
+        response = self.client.post(token_url, json=payload)
 
         if response.status_code < 200 or response.status_code >= 300:
             raise Exception(

--- a/src/airbyte_api/_hooks/clientcredentials.py
+++ b/src/airbyte_api/_hooks/clientcredentials.py
@@ -114,7 +114,7 @@ class ClientCredentialsHook(SDKInitHook, BeforeRequestHook, AfterErrorHook):
 
         token_url = credentials.token_url
         if not bool(urlparse(credentials.token_url).netloc):
-            token_url = urljoin(self.base_url, credentials.token_url)
+            token_url = self.base_url + credentials.token_url
 
         response = self.client.post(token_url, json=payload)
 


### PR DESCRIPTION
The use of urljoin on the do_token_request was creating a bug for the base configuration.

When the self.base_url was the default "https://api.airbyte.com/v1" and credentials was  the default "/applications/token", it did not work as expected

Expected result: "https://api.airbyte.com/v1/applications/token"
Real result: "https://api.airbyte.com/applications/token"

So the client auth did not work. Did a simple fix, since changing the self.base_url to "https://api.airbyte.com/v1/" broke other things

Versions used:
Python  3.10.10
urllib 2.5.0
airbyte sdk 0.53.0
Running on MacOS 12.6.6
