### PR TITLE
ci: use PYPI_TOKEN for publishing and fix infinite generate loop

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -5,7 +5,7 @@
 #
 # Triggers:
 # - On push to main: Auto-generates after every merge to ensure SDK stays up-to-date (auto-merge enabled)
-# - Daily schedule (5 AM & 5 PM Pacific): Catches upstream API spec changes (auto-merge enabled)
+# - Daily schedule (5 AM & 5 PM America/Los_Angeles): Catches upstream API spec changes (auto-merge enabled)
 # - Manual workflow_dispatch: For on-demand generation
 # - Slash command (/generate): Regenerates and pushes results back to the PR branch
 # - workflow_call: For validation from other workflows (e.g., PR checks)
@@ -30,8 +30,10 @@ name: Generate SDK
         branches:
             - main
     schedule:
-        - cron: '0 12 * * *'  # 5am Pacific (PDT; 6am PST)
-        - cron: '0 0 * * *'   # 5pm Pacific (PDT; 6pm PST)
+        - cron: '0 5 * * *'
+          timezone: America/Los_Angeles
+        - cron: '0 17 * * *'
+          timezone: America/Los_Angeles
     workflow_dispatch:
         inputs:
             dry_run:

--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -30,8 +30,8 @@ name: Generate SDK
         branches:
             - main
     schedule:
-        - cron: '0 12 * * *'
-        - cron: '0 0 * * *'
+        - cron: '0 12 * * *'  # 5am Pacific (PDT; 6am PST)
+        - cron: '0 0 * * *'   # 5pm Pacific (PDT; 6pm PST)
     workflow_dispatch:
         inputs:
             dry_run:

--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -5,7 +5,7 @@
 #
 # Triggers:
 # - On push to main: Auto-generates after every merge to ensure SDK stays up-to-date (auto-merge enabled)
-# - Daily schedule (6 AM UTC): Catches upstream API spec changes (auto-merge enabled)
+# - Daily schedule (5 AM & 5 PM Pacific): Catches upstream API spec changes (auto-merge enabled)
 # - Manual workflow_dispatch: For on-demand generation
 # - Slash command (/generate): Regenerates and pushes results back to the PR branch
 # - workflow_call: For validation from other workflows (e.g., PR checks)
@@ -30,7 +30,8 @@ name: Generate SDK
         branches:
             - main
     schedule:
-        - cron: '0 6 * * *'
+        - cron: '0 12 * * *'
+        - cron: '0 0 * * *'
     workflow_dispatch:
         inputs:
             dry_run:
@@ -203,6 +204,9 @@ jobs:
               if: ${{ !inputs.dry_run }}
               id: changes
               run: |
+                  # Restore workflow.lock to HEAD to ignore non-deterministic
+                  # digest changes that cause infinite generate→merge loops.
+                  git checkout HEAD -- .speakeasy/workflow.lock 2>/dev/null || true
                   if [ -n "$(git status --porcelain)" ]; then
                       echo "has_changes=true" >> $GITHUB_OUTPUT
                   else

--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -53,13 +53,9 @@ jobs:
   pre_release:
     name: Build & Publish Pre-Release
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/airbyte-api/
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     steps:
       # ── Slash command: post starting comment ────────────────────────
       - name: Authenticate as GitHub App
@@ -129,7 +125,9 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       # ── Tag the commit ──────────────────────────────────────────────
       - name: Create and push tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,10 @@
 # PyPI Publish Workflow
 #
 # Triggered when a GitHub Release is published (draft → published).
-# Builds the Python package and uploads it to PyPI using OIDC trusted publishing.
+# Builds the Python package and uploads it to PyPI using PYPI_TOKEN.
 #
 # Prerequisites:
-# - PyPI trusted publisher configured for this repository:
-#   https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
-#   Owner: airbytehq
-#   Repository: airbyte-api-python-sdk
-#   Workflow: publish.yml
-#   Environment: pypi
+# - PYPI_TOKEN secret configured in the repository
 
 name: Publish to PyPI
 
@@ -24,11 +19,6 @@ jobs:
   publish:
     name: Build & Publish to PyPI
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/airbyte-api/
-    permissions:
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,4 +32,6 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Three changes:

1. **PYPI_TOKEN for publishing**: Switches `publish.yml` and `pre-release-command.yml` from OIDC trusted publishing (`pypa/gh-action-pypi-publish` + `id-token: write`) to `uv publish` with `UV_PUBLISH_TOKEN`. OIDC requires PyPI Owner access to configure, which is blocked pending ownership transfer.

2. **Fix infinite generate→merge loop**: `generate-command.yml` restores `.speakeasy/workflow.lock` to HEAD before checking for changes. The `codeSamplesRevisionDigest` in this file is non-deterministic across runs, causing every generation to detect a diff, create a PR, auto-merge, and trigger another generation.

3. **Update schedule**: Generation schedule changed from daily 6am UTC to 5am & 5pm Pacific (`0 12 * * *` and `0 0 * * *`).

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers