### PR TITLE
ci: add GITHUB_TOKEN fallback when GitHub App secrets are unavailable

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -81,16 +81,22 @@ jobs:
             - name: Authenticate as GitHub App
               uses: actions/create-github-app-token@v3
               id: app-token
+              continue-on-error: true
               with:
                   app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
                   private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+            - name: Warn on GitHub App auth fallback
+              if: steps.app-token.outcome == 'failure'
+              run: |
+                  echo "::warning::GitHub App authentication failed (secrets may not be available in this context). Falling back to GITHUB_TOKEN."
 
             - name: Post or append starting comment
               if: ${{ !inputs.dry_run && github.event.inputs.pr != '' }}
               id: start-comment
               uses: peter-evans/create-or-update-comment@v5
               with:
-                  token: ${{ steps.app-token.outputs.token }}
+                  token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   issue-number: ${{ github.event.inputs.pr }}
                   comment-id: ${{ github.event.inputs.comment-id || '' }}
                   body: |
@@ -104,7 +110,7 @@ jobs:
               if: ${{ !inputs.dry_run && github.event.inputs.pr != '' }}
               id: pr-branch
               env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   PR_NUMBER: ${{ github.event.inputs.pr }}
               run: |
                   PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER})
@@ -121,7 +127,7 @@ jobs:
               with:
                   fetch-depth: 0
                   ref: ${{ steps.pr-branch.outputs.head_ref || '' }}
-                  token: ${{ steps.app-token.outputs.token }}
+                  token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
             - name: Install uv
               uses: astral-sh/setup-uv@v5
@@ -229,7 +235,7 @@ jobs:
               id: create-pr
               uses: peter-evans/create-pull-request@v6
               with:
-                  token: ${{ steps.app-token.outputs.token }}
+                  token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   commit-message: "chore: regenerate SDK with Speakeasy"
                   title: "chore: regenerate SDK with Speakeasy"
                   body: |
@@ -246,14 +252,14 @@ jobs:
                    || github.event_name == 'schedule'
                   ) && steps.create-pr.outputs.pull-request-operation == 'created'
               env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
               run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
 
             - name: Append success comment
               if: ${{ success() && !inputs.dry_run && github.event.inputs.pr != '' }}
               uses: peter-evans/create-or-update-comment@v5
               with:
-                  token: ${{ steps.app-token.outputs.token }}
+                  token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   comment-id: ${{ steps.start-comment.outputs.comment-id }}
                   reactions: hooray
                   body: |
@@ -263,7 +269,7 @@ jobs:
               if: ${{ failure() && !inputs.dry_run && github.event.inputs.pr != '' }}
               uses: peter-evans/create-or-update-comment@v5
               with:
-                  token: ${{ steps.app-token.outputs.token }}
+                  token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
                   comment-id: ${{ steps.start-comment.outputs.comment-id }}
                   reactions: confused
                   body: |

--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -81,7 +81,7 @@ jobs:
             - name: Authenticate as GitHub App
               uses: actions/create-github-app-token@v3
               id: app-token
-              continue-on-error: true
+              continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
               with:
                   app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
                   private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}

--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3
         id: app-token
-        continue-on-error: true
+        continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
         with:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}

--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -61,16 +61,22 @@ jobs:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3
         id: app-token
+        continue-on-error: true
         with:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Warn on GitHub App auth fallback
+        if: steps.app-token.outcome == 'failure'
+        run: |
+          echo "::warning::GitHub App authentication failed (secrets may not be available in this context). Falling back to GITHUB_TOKEN."
 
       - name: Post starting comment
         if: ${{ inputs.pr != '' }}
         id: start-comment
         uses: peter-evans/create-or-update-comment@v5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           issue-number: ${{ inputs.pr }}
           comment-id: ${{ inputs.comment-id || '' }}
           body: |
@@ -85,7 +91,7 @@ jobs:
         if: ${{ inputs.pr != '' && inputs.ref == 'main' }}
         id: resolve-ref
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           PR_HEAD=$(gh pr view "${{ inputs.pr }}" --repo "${{ github.repository }}" --json headRefName -q '.headRefName')
           echo "ref=$PR_HEAD" >> "$GITHUB_OUTPUT"
@@ -142,7 +148,7 @@ jobs:
         if: ${{ always() && inputs.pr != '' }}
         uses: peter-evans/create-or-update-comment@v5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           issue-number: ${{ inputs.pr }}
           body: |
             > **Pre-Release Result:** ${{ job.status == 'success' && 'Published' || 'Failed' }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -20,16 +20,22 @@ jobs:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3
         id: app-token
+        continue-on-error: true
         with:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Warn on GitHub App auth fallback
+        if: steps.app-token.outcome == 'failure'
+        run: |
+          echo "::warning::GitHub App authentication failed (secrets may not be available in this context). Falling back to GITHUB_TOKEN."
 
       - name: Slash Command Dispatch
         id: dispatch
         uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
         with:
           repository: ${{ github.repository }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           dispatch-type: workflow
           issue-type: pull-request
           commands: |

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v3
         id: app-token
-        continue-on-error: true
+        continue-on-error: ${{ github.actor == 'dependabot[bot]' }}
         with:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Fixes CI failures on Dependabot PRs (e.g. #155) where `OCTAVIA_BOT_APP_ID` / `OCTAVIA_BOT_PRIVATE_KEY` secrets are unavailable. Dependabot runs in a restricted context without access to repo Actions secrets.

**Change:** In all three workflows that use `actions/create-github-app-token@v3`, add `continue-on-error: true` and fall back to `secrets.GITHUB_TOKEN` when the App token is empty:

```yaml
- name: Authenticate as GitHub App
  uses: actions/create-github-app-token@v3
  id: app-token
  continue-on-error: true  # ← new
  ...

- name: Warn on GitHub App auth fallback
  if: steps.app-token.outcome == 'failure'  # ← only prints when App auth failed
  run: echo "::warning::..."

# All token references:
token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
```

**Affected workflows:** `generate-command.yml`, `pre-release-command.yml`, `slash-command-dispatch.yml`.

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers