### PR TITLE
ci: switch Dependabot from pip to uv ecosystem for proper uv.lock updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,8 @@ updates:
       - dependencies
       - github-actions
 
-  # Python dependencies (uv / pyproject.toml)
-  - package-ecosystem: pip
+  # Python dependencies (uv / pyproject.toml + uv.lock)
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary

Fixes Dependabot PRs failing the zero-diff check because `uv.lock` wasn't being updated alongside `pyproject.toml`.

`package-ecosystem: pip` only knows about `pyproject.toml` / `requirements.txt` — it doesn't run `uv lock`. Switching to `package-ecosystem: uv` tells Dependabot to update both `pyproject.toml` and `uv.lock` together, eliminating the generation drift on dependency bump PRs (e.g. #155).

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers