### PR TITLE
ci: scope generation validation to generation-affecting files only

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -54,6 +54,10 @@ name: Generate SDK
                 description: Validate generation without creating a PR
                 type: boolean
                 default: false
+            should_run:
+                description: Whether the generate job should run (false = skip). Used by callers to pass path-filter results so the job skips internally and reports as 'skipped' (satisfying required checks).
+                type: boolean
+                default: true
         outputs:
             has_changes:
                 description: Whether the generation produced changes vs committed code
@@ -69,6 +73,7 @@ concurrency:
 jobs:
     generate:
         name: Generate SDK
+        if: ${{ inputs.should_run != false }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         outputs:

--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -54,10 +54,6 @@ name: Generate SDK
                 description: Validate generation without creating a PR
                 type: boolean
                 default: false
-            should_run:
-                description: Whether the generate job should run (false = skip). Used by callers to pass path-filter results so the job skips internally and reports as 'skipped' (satisfying required checks).
-                type: boolean
-                default: true
         outputs:
             has_changes:
                 description: Whether the generation produced changes vs committed code
@@ -71,9 +67,36 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    check-paths:
+        name: Check Generation Paths
+        if: ${{ inputs.dry_run }}
+        runs-on: ubuntu-latest
+        outputs:
+            should_run: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.generation == 'true' }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Filter changed paths
+              uses: dorny/paths-filter@v4
+              id: filter
+              with:
+                  filters: |
+                      generation:
+                          - '.speakeasy/**'
+                          - '.genignore'
+                          - '.github/speakeasy/**'
+                          - '.github/workflows/generate-command.yml'
+                          - 'gen.yaml'
+                          - 'overlays/**'
+                          - 'README.md'
+                          - 'scripts/**'
+                          - 'poe_tasks.toml'
+                          - 'src/**'
+
     generate:
         name: Generate SDK
-        if: ${{ inputs.should_run != false }}
+        needs: [check-paths]
+        if: ${{ always() && (!inputs.dry_run || needs.check-paths.outputs.should_run == 'true') }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         outputs:

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -4,23 +4,14 @@
 # and that the committed generated code matches what the generation pipeline produces.
 #
 # Jobs:
-# 1. validate: Runs the full generation pipeline in dry-run mode
+# 1. validate: Calls generate-command.yml with dry_run=true. The generation
+#    workflow handles its own path filtering — it skips the Generate SDK job
+#    when only non-generation files changed (e.g., dev dependency bumps).
 # 2. zero-diff: Checks for drift using the validate job's outputs (in-place git status).
 #    If drift is detected, the check fails and posts a comment telling the author to run /generate.
 #
 # This workflow calls the main generation workflow with dry_run=true to ensure
 # both workflows use the same generation logic.
-#
-# Note: paths-ignore is NOT used at the workflow level because GitHub treats a
-# workflow that never runs as "expected" (pending), which blocks required checks.
-# Instead, we filter paths at the job level so skipped jobs report as "skipped"
-# (equivalent to "passed" for required checks).
-#
-# The path filter is scoped to generation-affecting files only (Speakeasy config,
-# gen.yaml, overlays, scripts, src/, etc.). Dev dependency updates (mypy, pylint,
-# etc.) skip the generation validation because they don't change generated
-# artifacts, and Dependabot PRs lack the SPEAKEASY_API_KEY secret needed to run
-# the generation pipeline.
 
 name: Test (Full)
 
@@ -33,44 +24,17 @@ permissions:
   pull-requests: write
 
 jobs:
-  check-paths:
-    name: Check Changed Paths
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Filter changed paths
-        uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            generation:
-              - '.speakeasy/**'
-              - '.genignore'
-              - '.github/speakeasy/**'
-              - '.github/workflows/generate-command.yml'
-              - 'gen.yaml'
-              - 'overlays/**'
-              - 'README.md'
-              - 'scripts/**'
-              - 'poe_tasks.toml'
-              - 'src/**'
-    outputs:
-      should_run: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.generation == 'true' }}
-
   validate:
     name: Validate Generation (Dry Run)
-    needs: check-paths
     uses: ./.github/workflows/generate-command.yml
     with:
       dry_run: true
-      should_run: ${{ needs.check-paths.outputs.should_run == 'true' }}
     secrets: inherit
 
   zero-diff:
     name: Zero-Diff Check (Generated Code)
-    needs: [check-paths, validate]
-    if: needs.check-paths.outputs.should_run == 'true' && github.event_name == 'pull_request'
+    needs: [validate]
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -18,7 +18,9 @@
 #
 # The path filter is scoped to generation-affecting files only (Speakeasy config,
 # gen.yaml, overlays, scripts, src/, etc.). Dev dependency updates (mypy, pylint,
-# etc.) skip the generation validation since they cannot affect generated code.
+# etc.) skip the generation validation because they don't change generated
+# artifacts, and Dependabot PRs lack the SPEAKEASY_API_KEY secret needed to run
+# the generation pipeline.
 
 name: Test (Full)
 

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -61,10 +61,10 @@ jobs:
   validate:
     name: Validate Generation (Dry Run)
     needs: check-paths
-    if: needs.check-paths.outputs.should_run == 'true'
     uses: ./.github/workflows/generate-command.yml
     with:
       dry_run: true
+      should_run: ${{ needs.check-paths.outputs.should_run == 'true' }}
     secrets: inherit
 
   zero-diff:

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -49,6 +49,7 @@ jobs:
               - '.github/workflows/generate-command.yml'
               - 'gen.yaml'
               - 'overlays/**'
+              - 'README.md'
               - 'scripts/**'
               - 'poe_tasks.toml'
               - 'src/**'

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -15,6 +15,10 @@
 # workflow that never runs as "expected" (pending), which blocks required checks.
 # Instead, we filter paths at the job level so skipped jobs report as "skipped"
 # (equivalent to "passed" for required checks).
+#
+# The path filter is scoped to generation-affecting files only (Speakeasy config,
+# gen.yaml, overlays, scripts, src/, etc.). Dev dependency updates (mypy, pylint,
+# etc.) skip the generation validation since they cannot affect generated code.
 
 name: Test (Full)
 
@@ -39,9 +43,15 @@ jobs:
         with:
           filters: |
             generation:
-              - '**'
-              - '!README.md'
-              - '!docs/**'
+              - '.speakeasy/**'
+              - '.genignore'
+              - '.github/speakeasy/**'
+              - '.github/workflows/generate-command.yml'
+              - 'gen.yaml'
+              - 'overlays/**'
+              - 'scripts/**'
+              - 'poe_tasks.toml'
+              - 'src/**'
     outputs:
       should_run: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.generation == 'true' }}
 


### PR DESCRIPTION
## Summary

Fixes generation validation failures on Dependabot dependency PRs (e.g. #170 mypy bump) where `SPEAKEASY_API_KEY` is unavailable and the generation check is unnecessary.

Two changes:

1. **Path filter narrowed** — `check-paths` in `test-full.yml` now matches only generation-affecting files (`.speakeasy/**`, `gen.yaml`, `overlays/**`, `src/**`, `scripts/**`, `README.md`, etc.) instead of `'**' - README - docs/`. Dev-only dependency bumps (`pyproject.toml` / `uv.lock`) no longer trigger generation validation.

2. **Skip condition moved into `generate-command.yml`** — new `should_run` boolean input (default `true`) on `workflow_call`. The `Generate SDK` job checks `if: ${{ inputs.should_run != false }}` and skips internally, so it reports as "skipped" in CI rather than never appearing — satisfying required check merge requirements. `test-full.yml`'s `validate` job always calls the inner workflow (no `if:` on the caller).

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers