### PR TITLE
ci: remove generate-command.yml from generation path filter

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -85,7 +85,6 @@ jobs:
                           - '.speakeasy/**'
                           - '.genignore'
                           - '.github/speakeasy/**'
-                          - '.github/workflows/generate-command.yml'
                           - 'gen.yaml'
                           - 'overlays/**'
                           - 'README.md'


### PR DESCRIPTION
## Summary

Removes `.github/workflows/generate-command.yml` from the generation path filter. Workflow file changes (like bumping `actions/checkout` in #169) don't affect generated code output, so they shouldn't trigger generation validation that requires `SPEAKEASY_API_KEY`.

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers