### PR TITLE
ci: switch dynamic versioning from file-based to git tag-based

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ build-backend = "hatchling.build"
 source = "uv-dynamic-versioning"
 
 [tool.uv-dynamic-versioning]
-[tool.uv-dynamic-versioning.from-file]
-source = "src/airbyte_api/_version.py"
-pattern = "__version__: str = \"(?P<version>[^\"]+)\""
+vcs = "git"
+style = "pep440"
+fallback-version = "0.0.0"
 
 [tool.hatch.build.targets.sdist]
 include = ["src/airbyte_api", "py.typed", "README-PYPI.md"]


### PR DESCRIPTION
## Summary

The `v1.0.0rc1` release published `1.0.0` to PyPI instead of `1.0.0rc1` because `uv-dynamic-versioning` was configured to read the version from `src/airbyte_api/_version.py` (which hardcodes `1.0.0`) rather than from git tags.

```diff
 [tool.uv-dynamic-versioning]
-[tool.uv-dynamic-versioning.from-file]
-source = "src/airbyte_api/_version.py"
-pattern = "__version__: str = \"(?P<version>[^\"]+)\""
+vcs = "git"
+style = "pep440"
+fallback-version = "0.0.0"
```

This matches the pattern used by PyAirbyte and airbyte-ops-mcp. The build version now comes from the git tag (e.g. `v1.0.0rc1` → `1.0.0rc1`), and dev builds without a tag resolve to `{last_tag}.postN.dev0+{sha}`.

Also adds `fetch-depth: 0` to `publish.yml` so the full tag history is available during release builds.

Verified locally:
- `git tag v1.0.0rc1` → builds `airbyte_api-1.0.0rc1-py3-none-any.whl`
- No tag on HEAD → builds `airbyte_api-0.53.0.post29.dev0+492ae670-py3-none-any.whl`

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers