### PR TITLE
ci: fix pre-release workflow to use UV_DYNAMIC_VERSIONING_BYPASS

### DIFF
--- a/.github/workflows/pre-release-command.yml
+++ b/.github/workflows/pre-release-command.yml
@@ -114,20 +114,16 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.resolve-ref.outputs.ref || inputs.ref }}
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      # ── Set version and build ───────────────────────────────────────
-      - name: Set pre-release version
-        run: |
-          VERSION="${{ inputs.version }}"
-          sed -i "s/^__version__: str = \".*\"/__version__: str = \"${VERSION}\"/" src/airbyte_api/_version.py
-          echo "Updated _version.py to: $VERSION"
-          grep '__version__' src/airbyte_api/_version.py
-
+      # ── Build with version override ───────────────────────────────
       - name: Build package
-        run: uv run poe build
+        run: uv build
+        env:
+          UV_DYNAMIC_VERSIONING_BYPASS: ${{ inputs.version }}
 
       - name: Publish to PyPI
         run: uv publish


### PR DESCRIPTION
## Summary

Follow-up to #175 (git tag-based versioning). The pre-release workflow was still using `sed` to edit `_version.py`, which is now ignored since the version comes from git tags.

```diff
-      - name: Set pre-release version
-        run: |
-          VERSION=\"${{ inputs.version }}\"
-          sed -i \"s/^__version__: str = \\\".*\\\"/__version__: str = \\\"${VERSION}\\\"/\" src/airbyte_api/_version.py
-
-      - name: Build package
-        run: uv run poe build
+      - name: Build package
+        run: uv build
+        env:
+          UV_DYNAMIC_VERSIONING_BYPASS: ${{ inputs.version }}
```

`UV_DYNAMIC_VERSIONING_BYPASS` overrides the VCS-derived version at build time — this is the same pattern PyAirbyte uses for its pre-release workflow.

Also adds `fetch-depth: 0` to the checkout step for consistency.

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers