### PR TITLE
Do not merge: experiment — enable sharedNestedComponentsJan2026 to test Schemas-pattern name recovery

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -12,7 +12,7 @@ generation:
     requestResponseComponentNamesFeb2024: false
     securityFeb2025: false
     sharedErrorComponentsApr2025: false
-    sharedNestedComponentsJan2026: false
+    sharedNestedComponentsJan2026: true
     nameOverrideFeb2026: false
   auth:
     oAuth2ClientCredentialsEnabled: true


### PR DESCRIPTION
## Summary

Research PR to measure the naming impact of enabling `fixes.sharedNestedComponentsJan2026: true`.

v0.53.0 → v1.0.0 lost 481 class names with the `Schemas` naming pattern (e.g. `DestinationAstraSchemasEmbeddingMode`). This flag \"fixes component naming when the same schema is referenced in multiple places within nested structures, ensuring consistent naming based on the original component definition.\" Testing whether it recovers any of those names or changes the naming pattern closer to v0.53.0.

Companion to PR #180 (closed — `nameResolutionFeb2025` revert hurt compat).

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers