### PR TITLE
Do not merge: experiment — enable requestResponseComponentNamesFeb2024 to test prefix name recovery

### DIFF
--- a/gen.yaml
+++ b/gen.yaml
@@ -9,7 +9,7 @@ generation:
     nameResolutionDec2023: true
     nameResolutionFeb2025: true
     parameterOrderingFeb2024: false
-    requestResponseComponentNamesFeb2024: false
+    requestResponseComponentNamesFeb2024: true
     securityFeb2025: false
     sharedErrorComponentsApr2025: false
     sharedNestedComponentsJan2026: false


### PR DESCRIPTION
## Summary

Research PR to measure the naming impact of enabling `fixes.requestResponseComponentNamesFeb2024: true`.

v0.53.0 → v1.0.0 lost 142 class names that got parent-prefixed (e.g. `APIHost` → `SourceEbayFulfillmentAPIHost`, `AWSRegion` → `SourceAmazonSellerPartnerAWSRegion`). This flag \"names inline schemas within request and response components with the component name of the parent if only one content type is defined.\" Testing whether it changes the prefixing behavior closer to v0.53.0.

Companion to PR #180 (closed) and PR #181 (`sharedNestedComponentsJan2026`).

Link to Devin session: https://app.devin.ai/sessions/854c664803f3400387fdaa02e123b888
Requested by: @aaronsteers